### PR TITLE
Fix conda-forge package name

### DIFF
--- a/cpp/bigquery/README.md
+++ b/cpp/bigquery/README.md
@@ -31,7 +31,7 @@ limitations under the License.
 1. Create and activate a new environment with the required C++ libraries:
 
    ```sh
-   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager arrow-cpp
+   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager libarrow
 
    # Initialize mamba in your shell if not already done
    eval "$(mamba shell hook --shell zsh)"

--- a/cpp/duckdb/README.md
+++ b/cpp/duckdb/README.md
@@ -27,7 +27,7 @@ limitations under the License.
 1. Create and activate a new environment with the required C++ libraries:
 
    ```sh
-   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager arrow-cpp
+   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager libarrow
 
    # Initialize mamba in your shell if not already done
    eval "$(mamba shell hook --shell zsh)"

--- a/cpp/flightsql/README.md
+++ b/cpp/flightsql/README.md
@@ -32,7 +32,7 @@ This example uses [Dremio](https://www.dremio.com/), but other open source tools
 1. Create and activate a new environment with the required C++ libraries:
 
    ```sh
-   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager arrow-cpp
+   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager libarrow
 
    # Initialize mamba in your shell if not already done
    eval "$(mamba shell hook --shell zsh)"

--- a/cpp/mssql/README.md
+++ b/cpp/mssql/README.md
@@ -32,7 +32,7 @@ limitations under the License.
 1. Create and activate a new environment with the required C++ libraries:
 
    ```sh
-   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager arrow-cpp
+   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager libarrow
 
    # Initialize mamba in your shell if not already done
    eval "$(mamba shell hook --shell zsh)"

--- a/cpp/mysql/README.md
+++ b/cpp/mysql/README.md
@@ -33,7 +33,7 @@ limitations under the License.
 1. Create and activate a new environment with the required C++ libraries:
 
    ```sh
-   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager arrow-cpp
+   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager libarrow
 
    # Initialize mamba in your shell if not already done
    eval "$(mamba shell hook --shell zsh)"

--- a/cpp/mysql/games.sql
+++ b/cpp/mysql/games.sql
@@ -26,7 +26,7 @@ CREATE TABLE `games` (
   `min_age` TINYINT UNSIGNED,
   `min_players` TINYINT UNSIGNED,
   `max_players` TINYINT UNSIGNED,
-  `list_price` DECIMAL(19,2), -- TODO: change to DECIMAL(5,2) after apache/arrow#48022 is fixed
+  `list_price` DECIMAL(5,2),
   PRIMARY KEY (`id`)
 );
 

--- a/cpp/postgresql/README.md
+++ b/cpp/postgresql/README.md
@@ -33,7 +33,7 @@ limitations under the License.
 1. Create and activate a new environment with the required C++ libraries:
 
    ```sh
-   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager arrow-cpp
+   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager libarrow
 
    # Initialize mamba in your shell if not already done
    eval "$(mamba shell hook --shell zsh)"

--- a/cpp/redshift/README.md
+++ b/cpp/redshift/README.md
@@ -29,7 +29,7 @@ limitations under the License.
 1. Create and activate a new environment with the required C++ libraries:
 
    ```sh
-   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager arrow-cpp
+   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager libarrow
 
    # Initialize mamba in your shell if not already done
    eval "$(mamba shell hook --shell zsh)"

--- a/cpp/snowflake/README.md
+++ b/cpp/snowflake/README.md
@@ -27,7 +27,7 @@ limitations under the License.
 1. Create and activate a new environment with the required C++ libraries:
 
    ```sh
-   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager arrow-cpp
+   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager libarrow
 
    # Initialize mamba in your shell if not already done
    eval "$(mamba shell hook --shell zsh)"

--- a/cpp/sqlite/README.md
+++ b/cpp/sqlite/README.md
@@ -30,7 +30,7 @@ limitations under the License.
 1. Create and activate a new environment with the required C++ libraries:
 
    ```sh
-   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager arrow-cpp
+   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager libarrow
 
    # Initialize mamba in your shell if not already done
    eval "$(mamba shell hook --shell zsh)"

--- a/cpp/trino/README.md
+++ b/cpp/trino/README.md
@@ -32,7 +32,7 @@ limitations under the License.
 1. Create and activate a new environment with the required C++ libraries:
 
    ```sh
-   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager arrow-cpp
+   mamba create -n adbc-cpp -c conda-forge cmake compilers libadbc-driver-manager libarrow
 
    # Initialize mamba in your shell if not already done
    eval "$(mamba shell hook --shell zsh)"


### PR DESCRIPTION
#1 accidentally used `arrow-cpp` instead of `libarrow`