### PR TITLE
chore: ignore go.sum and Cargo.lock for developments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 *.egg-info
 target
+go.sum
+Cargo.lock


### PR DESCRIPTION
It may be convenient to ignore these when updating this repository.