### PR TITLE
DO NOT MERGE: Modify examples to use connection profiles

### DIFF
--- a/python/postgresql/postgresql/README.md
+++ b/python/postgresql/postgresql/README.md
@@ -51,10 +51,10 @@ limitations under the License.
     dbc install postgresql
     ```
 
-2. Customize the Python script `main.py` as needed
-    - Change the connection arguments in `db_kwargs`
+2. Customize the connection profile `profile.toml` and the script `main.py` as needed
+    - Change the connection arguments in `profile.toml`
         - Format `uri` according to the [connection URI format used by PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS), or keep it as is to use the data included with this example
-    - If you changed which database you're connecting to, also change the SQL SELECT statement in `cursor.execute()`
+    - If you changed which database you're connecting to, also change the SQL SELECT statement in `cursor.execute()` in `main.py`
 
 3. Run the Python script:
 

--- a/python/postgresql/postgresql/main.py
+++ b/python/postgresql/postgresql/main.py
@@ -20,10 +20,11 @@
 from adbc_driver_manager import dbapi
 
 with (
-    dbapi.connect(
-        driver="postgresql",
-        db_kwargs={"uri": "postgresql://postgres:mysecretpassword@localhost:5432/demo"},
-    ) as con,
+    dbapi.connect(profile="./profile.toml") as con,
+    # or: dbapi.connect(uri="profile://./profile.toml")
+    # or: move `profile.toml` to the profile search location as documented at
+    #     https://arrow.apache.org/adbc/main/format/connection_profiles.html#profile-search-locations
+    #     and specify `profile="profile"` or `uri="profile://profile"`
     con.cursor() as cursor,
 ):
     cursor.execute("SELECT * FROM games;")

--- a/python/postgresql/postgresql/profile.toml
+++ b/python/postgresql/postgresql/profile.toml
@@ -1,0 +1,5 @@
+version = 1
+driver = "postgresql"
+
+[options]
+uri = "postgresql://postgres:mysecretpassword@localhost:5432/demo"


### PR DESCRIPTION
This modifies the PostgreSQL examples to use [connection profiles](https://arrow.apache.org/adbc/main/format/connection_profiles.html), as enabled by https://github.com/apache/arrow-adbc/pull/3876 and https://github.com/apache/arrow-adbc/pull/4078.

Currently this only modifies the Python example for PostgreSQL.