### PR TITLE
Fix Python Trino quickstart catalog typo and macOS install step

### DIFF
--- a/java/trino/src/main/java/tech/columnar/Example.java
+++ b/java/trino/src/main/java/tech/columnar/Example.java
@@ -33,7 +33,7 @@ public class Example {
   public static void main(String[] args) throws Exception {
     Map<String, Object> params = new HashMap<>();
     JniDriver.PARAM_DRIVER.set(params, "trino");
-    params.put("uri", "http://user@localhost:8080?catalog=tcph&schema=tiny");
+    params.put("uri", "http://user@localhost:8080?catalog=tpch&schema=tiny");
 
     try (BufferAllocator allocator = new RootAllocator();
         AdbcDatabase db =

--- a/kotlin/trino/src/main/kotlin/Main.kt
+++ b/kotlin/trino/src/main/kotlin/Main.kt
@@ -23,7 +23,7 @@ private const val DRIVER_FACTORY = "org.apache.arrow.adbc.driver.jni.JniDriverFa
 fun main() {
     val params = mutableMapOf<String, Any>()
     JniDriver.PARAM_DRIVER.set(params, "trino")
-    params["uri"] = "http://user@localhost:8080?catalog=tcph&schema=tiny"
+    params["uri"] = "http://user@localhost:8080?catalog=tpch&schema=tiny"
 
     RootAllocator().use { allocator ->
         AdbcDriverManager.getInstance().connect(DRIVER_FACTORY, allocator, params).use { db ->

--- a/python/trino/README.md
+++ b/python/trino/README.md
@@ -42,7 +42,7 @@ limitations under the License.
 1. Install the Trino ADBC driver:
 
    ```sh
-   dbc install trino
+   dbc install trino --level user
    ```
 
 1. Customize the Python script `main.py` as needed

--- a/python/trino/main.py
+++ b/python/trino/main.py
@@ -22,7 +22,7 @@ from adbc_driver_manager import dbapi
 with (
     dbapi.connect(
         driver="trino",
-        db_kwargs={"uri": "http://user@localhost:8080?catalog=tcph&schema=tiny"},
+        db_kwargs={"uri": "http://user@localhost:8080?catalog=tpch&schema=tiny"},
     ) as con,
     con.cursor() as cursor,
 ):


### PR DESCRIPTION
## Summary
- Fix `catalog=tcph` → `catalog=tpch` typo in `python/trino/main.py`. The example worked only because the SELECT fully qualifies the table; a user copying the URI and running an unqualified query would hit a confusing "catalog not found" error.
- Update `python/trino/README.md` to recommend `dbc install trino --level user`, matching the workaround that resolved #96 (macOS dlopen failure when the driver is installed at the default level).

## Test plan
- [x] `uv run python/trino/main.py` against a local `trinodb/trino` Docker container returns the 5 TPC-H nation rows.
- [x] Fresh macOS install: `dbc install trino --level user` lands the driver in a path the ADBC driver manager searches without setting `ADBC_DRIVER_PATH`.