### PR TITLE
DO NOT MERGE: Modify examples to use connection profiles

### DIFF
--- a/cpp/postgresql/postgresql/README.md
+++ b/cpp/postgresql/postgresql/README.md
@@ -51,10 +51,10 @@ limitations under the License.
     dbc install --level user postgresql
     ```
 
-2. Customize the C++ program `main.cpp` as needed
-    - Change the connection arguments in the `AdbcDatabaseSetOption()` calls
+2. Customize the connection profile `profile.toml` and the C++ program `main.cpp` as needed
+    - Change the connection arguments in `profile.toml`
         - Format `uri` according to the [connection URI format used by PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS), or keep it as is to use the data included with this example
-    - If you changed which database you're connecting to, also change the SQL SELECT statement in `AdbcStatementSetSqlQuery()`
+    - If you changed which database you're connecting to, also change the SQL SELECT statement in `AdbcStatementSetSqlQuery()` in `main.cpp`
 
 3. Build and run the C++ program:
 

--- a/cpp/postgresql/postgresql/main.cpp
+++ b/cpp/postgresql/postgresql/main.cpp
@@ -54,8 +54,8 @@ int main() {
 
   CHECK_ADBC(AdbcDatabaseSetOption(
       &database, "uri", "profile://./profile.toml", &error));
-  // or: CHECK_ADBC(
-  //     AdbcDatabaseSetOption(&database, "profile", "profile", &error));
+  // or: CHECK_ADBC(AdbcDatabaseSetOption(
+  //     &database, "profile", "./profile.toml", &error));
   CHECK_ADBC(AdbcDriverManagerDatabaseSetLoadFlags(
       &database, ADBC_LOAD_FLAG_DEFAULT, &error));
   CHECK_ADBC(AdbcDatabaseInit(&database, &error));

--- a/cpp/postgresql/postgresql/main.cpp
+++ b/cpp/postgresql/postgresql/main.cpp
@@ -52,9 +52,10 @@ int main() {
   AdbcDatabase database = {};
   CHECK_ADBC(AdbcDatabaseNew(&database, &error));
 
-  CHECK_ADBC(AdbcDatabaseSetOption(&database, "driver", "postgresql", &error));
-  CHECK_ADBC(AdbcDatabaseSetOption(&database, "uri",
-                                   "postgresql://postgres:mysecretpassword@localhost:5432/demo", &error));
+  CHECK_ADBC(AdbcDatabaseSetOption(
+      &database, "uri", "profile://./profile.toml", &error));
+  // or: CHECK_ADBC(
+  //     AdbcDatabaseSetOption(&database, "profile", "profile", &error));
   CHECK_ADBC(AdbcDriverManagerDatabaseSetLoadFlags(
       &database, ADBC_LOAD_FLAG_DEFAULT, &error));
   CHECK_ADBC(AdbcDatabaseInit(&database, &error));

--- a/cpp/postgresql/postgresql/profile.toml
+++ b/cpp/postgresql/postgresql/profile.toml
@@ -1,0 +1,5 @@
+profile_version = 1
+driver = "postgresql"
+
+[Options]
+uri = "postgresql://postgres:mysecretpassword@localhost:5432/demo"

--- a/go/go.mod
+++ b/go/go.mod
@@ -14,25 +14,27 @@
 
 module github.com/columnar/adbc-examples/go
 
-go 1.24.0
+go 1.25.0
 
-require github.com/apache/arrow-adbc/go/adbc v1.8.0
+require github.com/apache/arrow-adbc/go/adbc v1.11.0
 
 require (
-	github.com/apache/arrow-go/v18 v18.4.1 // indirect
+	github.com/apache/arrow-go/v18 v18.5.2 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
-	github.com/google/flatbuffers v25.2.10+incompatible // indirect
-	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/google/flatbuffers v25.12.19+incompatible // indirect
+	github.com/klauspost/compress v1.18.4 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
-	github.com/pierrec/lz4/v4 v4.1.22 // indirect
-	github.com/zeebo/xxh3 v1.0.2 // indirect
-	go.opentelemetry.io/otel v1.38.0 // indirect
-	go.opentelemetry.io/otel/trace v1.38.0 // indirect
-	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
-	golang.org/x/mod v0.27.0 // indirect
-	golang.org/x/sync v0.17.0 // indirect
-	golang.org/x/sys v0.35.0 // indirect
-	golang.org/x/tools v0.36.0 // indirect
+	github.com/pierrec/lz4/v4 v4.1.25 // indirect
+	github.com/zeebo/xxh3 v1.1.0 // indirect
+	go.opentelemetry.io/otel v1.42.0 // indirect
+	go.opentelemetry.io/otel/trace v1.42.0 // indirect
+	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
+	golang.org/x/mod v0.34.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c // indirect
+	golang.org/x/tools v0.43.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
-	google.golang.org/protobuf v1.36.8 // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/go/postgresql/postgresql/README.md
+++ b/go/postgresql/postgresql/README.md
@@ -51,10 +51,10 @@ limitations under the License.
     dbc install postgresql
     ```
 
-2. Customize the Go program `main.go` as needed
-    - Change the connection arguments in the `NewDatabase()` call
+2. Customize the connection profile `profile.toml` and the Go program `main.go` as needed
+    - Change the connection arguments in `profile.toml`
         - Format `uri` according to the [connection URI format used by PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS), or keep it as is to use the data included with this example
-    - If you changed which database you're connecting to, also change the SQL SELECT statement in `stmt.SetSqlQuery()`
+    - If you changed which database you're connecting to, also change the SQL SELECT statement in `stmt.SetSqlQuery()` in `main.go`
 
 3. Run the Go program:
 

--- a/go/postgresql/postgresql/main.go
+++ b/go/postgresql/postgresql/main.go
@@ -26,8 +26,8 @@ func main() {
 	var drv drivermgr.Driver
 
 	db, err := drv.NewDatabase(map[string]string{
-		"driver": "postgresql",
-		"uri":    "postgresql://postgres:mysecretpassword@localhost:5432/demo",
+		"uri": "profile://./profile.toml",
+		// or: "profile": "./profile.toml",
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/go/postgresql/postgresql/profile.toml
+++ b/go/postgresql/postgresql/profile.toml
@@ -1,0 +1,5 @@
+profile_version = 1
+driver = "postgresql"
+
+[Options]
+uri = "postgresql://postgres:mysecretpassword@localhost:5432/demo"

--- a/java/postgresql/postgresql/README.md
+++ b/java/postgresql/postgresql/README.md
@@ -54,7 +54,7 @@ limitations under the License.
 2. Customize the connection profile `profile.toml` and the `main` method in `Example.java` as needed
     - Change the connection arguments in `profile.toml`
         - Format `uri` according to the [connection URI format used by PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS), or keep it as is to use the data included with this example
-    - If you changed which database you're connecting to, also change the SQL SELECT statement in `stmt.setSqlQuery()`
+    - If you changed which database you're connecting to, also change the SQL SELECT statement in `stmt.setSqlQuery()` in `Example.java`
 
 3. Run the Java program:
 

--- a/java/postgresql/postgresql/README.md
+++ b/java/postgresql/postgresql/README.md
@@ -51,8 +51,8 @@ limitations under the License.
     dbc install postgresql
     ```
 
-2. Customize the `main` method in `Example.java`
-    - Change the connection arguments in the `params.put()` calls
+2. Customize the connection profile `profile.toml` and the `main` method in `Example.java` as needed
+    - Change the connection arguments in `profile.toml`
         - Format `uri` according to the [connection URI format used by PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS), or keep it as is to use the data included with this example
     - If you changed which database you're connecting to, also change the SQL SELECT statement in `stmt.setSqlQuery()`
 

--- a/java/postgresql/postgresql/pom.xml
+++ b/java/postgresql/postgresql/pom.xml
@@ -29,7 +29,7 @@ limitations under the License.
         <maven.compiler.release>17</maven.compiler.release>
         <exec.mainClass>tech.columnar.Example</exec.mainClass>
         <arrow.version>18.3.0</arrow.version>
-        <adbc.version>0.21.0</adbc.version>
+        <adbc.version>0.24.0</adbc.version>
     </properties>
 
     <dependencyManagement>

--- a/java/postgresql/postgresql/profile.toml
+++ b/java/postgresql/postgresql/profile.toml
@@ -1,0 +1,5 @@
+profile_version = 1
+driver = "postgresql"
+
+[Options]
+uri = "postgresql://postgres:mysecretpassword@localhost:5432/demo"

--- a/java/postgresql/postgresql/src/main/java/tech/columnar/Example.java
+++ b/java/postgresql/postgresql/src/main/java/tech/columnar/Example.java
@@ -33,7 +33,7 @@ public class Example {
   public static void main(String[] args) throws Exception {
     Map<String, Object> params = new HashMap<>();
     JniDriver.PARAM_URI.set(params, "profile://./profile.toml");
-    // or: JniDriver.PARAM_PROFILE.set(params, "foo");
+    // or: JniDriver.PARAM_PROFILE.set(params, "profile");
 
     try (BufferAllocator allocator = new RootAllocator();
         AdbcDatabase db =

--- a/java/postgresql/postgresql/src/main/java/tech/columnar/Example.java
+++ b/java/postgresql/postgresql/src/main/java/tech/columnar/Example.java
@@ -32,8 +32,7 @@ public class Example {
 
   public static void main(String[] args) throws Exception {
     Map<String, Object> params = new HashMap<>();
-    JniDriver.PARAM_DRIVER.set(params, "postgresql");
-    params.put("uri", "postgresql://postgres:mysecretpassword@localhost:5432/demo");
+    JniDriver.PARAM_URI.set(params, "profile://./profile.toml");
 
     try (BufferAllocator allocator = new RootAllocator();
         AdbcDatabase db =

--- a/java/postgresql/postgresql/src/main/java/tech/columnar/Example.java
+++ b/java/postgresql/postgresql/src/main/java/tech/columnar/Example.java
@@ -33,7 +33,7 @@ public class Example {
   public static void main(String[] args) throws Exception {
     Map<String, Object> params = new HashMap<>();
     JniDriver.PARAM_URI.set(params, "profile://./profile.toml");
-    // or: JniDriver.PARAM_PROFILE.set(params, "profile");
+    // or: JniDriver.PARAM_PROFILE.set(params, "./profile.toml");
 
     try (BufferAllocator allocator = new RootAllocator();
         AdbcDatabase db =

--- a/java/postgresql/postgresql/src/main/java/tech/columnar/Example.java
+++ b/java/postgresql/postgresql/src/main/java/tech/columnar/Example.java
@@ -33,6 +33,7 @@ public class Example {
   public static void main(String[] args) throws Exception {
     Map<String, Object> params = new HashMap<>();
     JniDriver.PARAM_URI.set(params, "profile://./profile.toml");
+    // or: JniDriver.PARAM_PROFILE.set(params, "foo");
 
     try (BufferAllocator allocator = new RootAllocator();
         AdbcDatabase db =

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@apache-arrow/adbc-driver-manager": "0.23.0",
+    "@apache-arrow/adbc-driver-manager": "0.24.0",
     "apache-arrow": "^21.1.0"
   }
 }

--- a/javascript/postgresql/postgresql/README.md
+++ b/javascript/postgresql/postgresql/README.md
@@ -58,10 +58,10 @@ limitations under the License.
    npm --prefix ../.. install
    ```
 
-1. Customize the script `main.js` as needed
-   - Change the connection arguments in `databaseOptions`
+1. Customize the connection profile `profile.toml` and the script `main.js` as needed
+   - Change the connection arguments in `profile.toml`
      - Format `uri` according to the [connection URI format used by PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS), or keep it as is to use the data included with this example
-   - If you changed which database you're connecting to, also change the SQL SELECT statement in `conn.query()`
+   - If you changed which database you're connecting to, also change the SQL SELECT statement in `conn.query()` in `main.js`
 
 1. Run the script:
 

--- a/javascript/postgresql/postgresql/main.js
+++ b/javascript/postgresql/postgresql/main.js
@@ -15,7 +15,8 @@
 import { AdbcDatabase } from '@apache-arrow/adbc-driver-manager';
 
 const db = new AdbcDatabase({
-  driver: 'profile://./profile.toml',
+  databaseOptions: { uri: 'profile://./profile.toml' },
+  // or: databaseOptions: { profile: './profile.toml' },
 });
 
 let conn;

--- a/javascript/postgresql/postgresql/main.js
+++ b/javascript/postgresql/postgresql/main.js
@@ -15,10 +15,7 @@
 import { AdbcDatabase } from '@apache-arrow/adbc-driver-manager';
 
 const db = new AdbcDatabase({
-  driver: 'postgresql',
-  databaseOptions: {
-    uri: 'postgresql://postgres:mysecretpassword@localhost:5432/demo',
-  },
+  driver: 'profile://./profile.toml',
 });
 
 let conn;

--- a/javascript/postgresql/postgresql/profile.toml
+++ b/javascript/postgresql/postgresql/profile.toml
@@ -1,0 +1,5 @@
+profile_version = 1
+driver = "postgresql"
+
+[Options]
+uri = "postgresql://postgres:mysecretpassword@localhost:5432/demo"

--- a/python/postgresql/postgresql/README.md
+++ b/python/postgresql/postgresql/README.md
@@ -51,10 +51,10 @@ limitations under the License.
     dbc install postgresql
     ```
 
-2. Customize the Python script `main.py` as needed
-    - Change the connection arguments in `db_kwargs`
+2. Customize the connection profile `profile.toml` and the script `main.py` as needed
+    - Change the connection arguments in `profile.toml`
         - Format `uri` according to the [connection URI format used by PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS), or keep it as is to use the data included with this example
-    - If you changed which database you're connecting to, also change the SQL SELECT statement in `cursor.execute()`
+    - If you changed which database you're connecting to, also change the SQL SELECT statement in `cursor.execute()` in `main.py`
 
 3. Run the Python script:
 

--- a/python/postgresql/postgresql/main.py
+++ b/python/postgresql/postgresql/main.py
@@ -20,10 +20,11 @@
 from adbc_driver_manager import dbapi
 
 with (
-    dbapi.connect(
-        driver="postgresql",
-        db_kwargs={"uri": "postgresql://postgres:mysecretpassword@localhost:5432/demo"},
-    ) as con,
+    dbapi.connect(profile="./profile.toml") as con,
+    # or: dbapi.connect(uri="profile://./profile.toml")
+    # or: move `profile.toml` to the profile search location as documented at
+    #     https://arrow.apache.org/adbc/main/format/connection_profiles.html#profile-search-locations
+    #     and specify `profile="profile"` or `uri="profile://profile"`
     con.cursor() as cursor,
 ):
     cursor.execute("SELECT * FROM games;")

--- a/python/postgresql/postgresql/main.py
+++ b/python/postgresql/postgresql/main.py
@@ -20,11 +20,11 @@
 from adbc_driver_manager import dbapi
 
 with (
-    dbapi.connect(profile="./profile.toml") as con,
-    # or: dbapi.connect(uri="profile://./profile.toml")
+    dbapi.connect(uri="profile://./profile.toml") as con,
+    # or: dbapi.connect(profile="./profile.toml") as con,
     # or: move `profile.toml` to the profile search location as documented at
     #     https://arrow.apache.org/adbc/main/format/connection_profiles.html#profile-search-locations
-    #     and specify `profile="profile"` or `uri="profile://profile"`
+    #     and specify `uri="profile://profile"` or `profile="profile"`
     con.cursor() as cursor,
 ):
     cursor.execute("SELECT * FROM games;")

--- a/python/postgresql/postgresql/profile.toml
+++ b/python/postgresql/postgresql/profile.toml
@@ -1,0 +1,5 @@
+version = 1
+driver = "postgresql"
+
+[options]
+uri = "postgresql://postgres:mysecretpassword@localhost:5432/demo"

--- a/python/postgresql/postgresql/profile.toml
+++ b/python/postgresql/postgresql/profile.toml
@@ -1,5 +1,5 @@
-version = 1
+profile_version = 1
 driver = "postgresql"
 
-[options]
+[Options]
 uri = "postgresql://postgres:mysecretpassword@localhost:5432/demo"

--- a/r/postgresql/postgresql/README.md
+++ b/r/postgresql/postgresql/README.md
@@ -57,10 +57,10 @@ limitations under the License.
     dbc install postgresql
     ```
 
-2. Customize the R script `main.R` as needed
-    - Change the connection arguments in `adbc_database_init()`
+2. Customize the connection profile `profile.toml` and the R script `main.R` as needed
+    - Change the connection arguments in `profile.toml`
         - Format `uri` according to the [connection URI format used by PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS), or keep it as is to use the data included with this example
-    - If you changed which database you're connecting to, also change the SQL SELECT statement in `read_adbc()`
+    - If you changed which database you're connecting to, also change the SQL SELECT statement in `read_adbc()` in `main.R`
 
 3. Run the R script:
 

--- a/r/postgresql/postgresql/main.R
+++ b/r/postgresql/postgresql/main.R
@@ -14,11 +14,12 @@
 
 library(adbcdrivermanager)
 
-drv <- adbc_driver("postgresql")
+# TODO: This does not currently work
+# See https://github.com/apache/arrow-adbc/issues/4532
 
 db <- adbc_database_init(
-  drv,
-  uri = "postgresql://postgres:mysecretpassword@localhost:5432/demo"
+  uri = "profile://./profile.toml"
+  # or: profile = "profile"
 )
 
 con <- adbc_connection_init(db)

--- a/r/postgresql/postgresql/main.R
+++ b/r/postgresql/postgresql/main.R
@@ -14,9 +14,6 @@
 
 library(adbcdrivermanager)
 
-# TODO: This does not currently work
-# See https://github.com/apache/arrow-adbc/issues/4532
-
 db <- adbc_database_init(
   uri = "profile://./profile.toml"
   # or: profile = "./profile.toml"

--- a/r/postgresql/postgresql/main.R
+++ b/r/postgresql/postgresql/main.R
@@ -19,7 +19,7 @@ library(adbcdrivermanager)
 
 db <- adbc_database_init(
   uri = "profile://./profile.toml"
-  # or: profile = "profile"
+  # or: profile = "./profile.toml"
 )
 
 con <- adbc_connection_init(db)

--- a/r/postgresql/postgresql/profile.toml
+++ b/r/postgresql/postgresql/profile.toml
@@ -1,0 +1,5 @@
+profile_version = 1
+driver = "postgresql"
+
+[Options]
+uri = "postgresql://postgres:mysecretpassword@localhost:5432/demo"

--- a/ruby/postgresql/postgresql/README.md
+++ b/ruby/postgresql/postgresql/README.md
@@ -103,10 +103,10 @@ limitations under the License.
     dbc install --level user postgresql
     ```
 
-2. Customize the Ruby script `main.rb` as needed
-    - Change the connection arguments in `database.set_option()`
+2. Customize the connection profile `profile.toml` and the Ruby script `main.rb` as needed
+    - Change the connection arguments in `profile.toml`
         - Format `uri` according to the [connection URI format used by PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS), or keep it as is to use the data included with this example
-    - If you changed which database you're connecting to, also change the SQL SELECT statement in `connection.query()`
+    - If you changed which database you're connecting to, also change the SQL SELECT statement in `connection.query()` in `main.rb`
 
 3. Run the Ruby script:
 

--- a/ruby/postgresql/postgresql/main.rb
+++ b/ruby/postgresql/postgresql/main.rb
@@ -17,13 +17,13 @@ require "adbc"
 database = ADBC::Database.new
 
 begin
-  database.set_option("driver", "postgresql")
-  database.set_option("uri", "postgresql://postgres:mysecretpassword@localhost:5432/demo")
+  database.set_option("uri", "profile://./profile.toml")
+  # or: database.set_option("profile", "./profile.toml")
   database.set_load_flags(ADBC::LoadFlags::DEFAULT)
   database.init
 
   database.connect do |connection|
-    table, = connection.query("SELECT * FROM games;")
+    table, = connection.query("SELECT name, inventor, year FROM games;")
     puts(table)
   end
 ensure

--- a/ruby/postgresql/postgresql/profile.toml
+++ b/ruby/postgresql/postgresql/profile.toml
@@ -1,0 +1,5 @@
+profile_version = 1
+driver = "postgresql"
+
+[Options]
+uri = "postgresql://postgres:mysecretpassword@localhost:5432/demo"

--- a/rust/postgresql/postgresql/Cargo.toml
+++ b/rust/postgresql/postgresql/Cargo.toml
@@ -18,7 +18,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-adbc_core = "0.21.0"
-adbc_driver_manager = "0.21.0"
+adbc_core = "0.23.0"
+adbc_driver_manager = "0.23.0"
 arrow = { version = "57.0.0", features = ["prettyprint"] }
 arrow-array = "57.0.0"

--- a/rust/postgresql/postgresql/README.md
+++ b/rust/postgresql/postgresql/README.md
@@ -51,10 +51,10 @@ limitations under the License.
     dbc install postgresql
     ```
 
-2. Customize `src/main.rs` as needed
-    - Change the connection arguments in `opts`
-        - Format `OptionDatabase::Uri` according to the [connection URI format used by PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS), or keep it as is to use the data included with this example
-    - If you changed which database you're connecting to, also change the SQL SELECT statement in `statement.set_sql_query()`
+2. Customize the connection profile `profile.toml` and the Rust program `src/main.rs` as needed
+    - Change the connection arguments in `profile.toml`
+        - Format `uri` according to the [connection URI format used by PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS), or keep it as is to use the data included with this example
+    - If you changed which database you're connecting to, also change the SQL SELECT statement in `statement.set_sql_query()` in `main.rs`
 
 3. Run the Rust program:
 

--- a/rust/postgresql/postgresql/profile.toml
+++ b/rust/postgresql/postgresql/profile.toml
@@ -1,0 +1,5 @@
+profile_version = 1
+driver = "postgresql"
+
+[Options]
+uri = "postgresql://postgres:mysecretpassword@localhost:5432/demo"

--- a/rust/postgresql/postgresql/src/main.rs
+++ b/rust/postgresql/postgresql/src/main.rs
@@ -12,28 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use adbc_core::options::{AdbcVersion, OptionDatabase};
-use adbc_core::{Connection, Database, Driver, LOAD_FLAG_DEFAULT, Statement};
-use adbc_driver_manager::ManagedDriver;
+use adbc_core::options::AdbcVersion;
+use adbc_core::{Connection, Database, LOAD_FLAG_DEFAULT, Statement};
+use adbc_driver_manager::ManagedDatabase;
 use arrow::util::pretty;
 use arrow_array::RecordBatch;
 
 fn main() {
-    let mut driver = ManagedDriver::load_from_name(
-        "postgresql",
-        None,
-        AdbcVersion::default(),
-        LOAD_FLAG_DEFAULT,
-        None,
-    )
-    .expect("Failed to load driver");
-
-    let opts = [(
-        OptionDatabase::Uri,
-        "postgresql://postgres:mysecretpassword@localhost:5432/demo".into(),
-    )];
-    let db = driver
-        .new_database_with_opts(opts)
+    let uri = "profile://./profile.toml";
+    let db = ManagedDatabase::from_uri(uri, None, AdbcVersion::default(), LOAD_FLAG_DEFAULT, None)
         .expect("Failed to create database handle");
 
     let mut conn = db.new_connection().expect("Failed to create connection");


### PR DESCRIPTION
This modifies most of the PostgreSQL examples to use [connection profiles](https://arrow.apache.org/adbc/main/format/connection_profiles.html), as enabled by https://github.com/apache/arrow-adbc/pull/3876 and https://github.com/apache/arrow-adbc/pull/4078.